### PR TITLE
Deleting sudoer acces

### DIFF
--- a/odoo_install.sh
+++ b/odoo_install.sh
@@ -93,8 +93,6 @@ fi
 	
 echo -e "\n---- Create ODOO system user ----"
 sudo adduser --system --quiet --shell=/bin/bash --home=$OE_HOME --gecos 'ODOO' --group $OE_USER
-#The user should also be added to the sudo'ers group.
-sudo adduser $OE_USER sudo
 
 echo -e "\n---- Create Log directory ----"
 sudo mkdir /var/log/$OE_USER


### PR DESCRIPTION
The odoo user is a system user, created even without shell access rights and no password, because his solely purpose is to run the whole odoo process and that's all. The odoo user should not have any access level to the system beyond the scope of his own software.

Sudoers access should only be given to known system administrators. It adds an small overhead, but it's worth it as an small exchange from a good security policy point of view.
