### PR TITLE
Use Postgresql 9.6 on Ubuntu 16.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,17 @@ This script can be safely used in a multi-odoo code base server because the defa
 <h3>Installation procedure</h3>
 1. Download the script:
 ```
-sudo wget https://raw.githubusercontent.com/Yenthe666/InstallScript/9.0/odoo_install.sh
+sudo wget https://raw.githubusercontent.com/Yenthe666/InstallScript/All/odoo_install.sh
 ```
-2. Make the script executable:
+2. Modify the parameters as you wish.
+There are a few things you can configure, this is the most used list:<br/>
+```OE_USER``` will be the username for the system user.<br/>
+```INSTALL_WKHTMLTOPDF``` set to ```False``` if you do not want to install it, if you want to install it you should set it to ```True```.<br/>
+```OE_PORT``` is the port where Odoo should run on, for example 8069.<br/>
+```OE_VERSION``` is the Odoo version to install, for example ```9.0``` for Odoo V9.<br/>
+```IS_ENTERPRISE``` will install the Enterprise version on top of ```9.0``` if you set it to ```True```, set it to ```False``` if you want the community version of Odoo 9.<br/>
+```OE_SUPERADMIN``` is the master password for this Odoo installation.<br/>
+3. Make the script executable
 ```
 sudo chmod +x odoo_install.sh
 ```

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ but goes a bit further. This script will also give you the ability to define an 
 This script can be safely used in a multi-odoo code base server because the default Odoo port is changed BEFORE the Odoo is started.
 
 <h3>Installation procedure</h3>
-1. Download the script:
+- 1. Download the script:
 ```
 sudo wget https://raw.githubusercontent.com/Yenthe666/InstallScript/All/odoo_install.sh
 ```
-2. Modify the parameters as you wish.
+- 2. Modify the parameters as you wish.
 There are a few things you can configure, this is the most used list:<br/>
 ```OE_USER``` will be the username for the system user.<br/>
 ```INSTALL_WKHTMLTOPDF``` set to ```False``` if you do not want to install it, if you want to install it you should set it to ```True```.<br/>
@@ -15,11 +15,11 @@ There are a few things you can configure, this is the most used list:<br/>
 ```OE_VERSION``` is the Odoo version to install, for example ```9.0``` for Odoo V9.<br/>
 ```IS_ENTERPRISE``` will install the Enterprise version on top of ```9.0``` if you set it to ```True```, set it to ```False``` if you want the community version of Odoo 9.<br/>
 ```OE_SUPERADMIN``` is the master password for this Odoo installation.<br/>
-3. Make the script executable
+- 3. Make the script executable
 ```
 sudo chmod +x odoo_install.sh
 ```
-3. Execute the script:
+- 4. Execute the script:
 ```
 sudo ./odoo_install.sh
 ```

--- a/odoo_install.sh
+++ b/odoo_install.sh
@@ -38,8 +38,8 @@ OE_CONFIG="${OE_USER}-server"
 ## === Ubuntu Trusty x64 & x32 === (for other distributions please replace these two links,
 ## in order to have correct version of wkhtmltox installed, for a danger note refer to 
 ## https://www.odoo.com/documentation/8.0/setup/install.html#deb ):
-WKHTMLTOX_X64=http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb
-WKHTMLTOX_X32=http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-i386.deb
+WKHTMLTOX_X64=https://downloads.wkhtmltopdf.org/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb
+WKHTMLTOX_X32=https://downloads.wkhtmltopdf.org/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-i386.deb
 
 #--------------------------------------------------
 # Update Server

--- a/odoo_install.sh
+++ b/odoo_install.sh
@@ -112,9 +112,7 @@ sudo git clone --depth 1 --branch $OE_VERSION https://www.github.com/odoo/odoo $
 
 if [ $IS_ENTERPRISE = "True" ]; then
     # Odoo Enterprise install!
-	echo -e "\n--- Create symlink for node"
-    sudo ln -s /usr/bin/nodejs /usr/bin/node
-	sudo su $OE_USER -c "mkdir $OE_HOME/enterprise"
+    sudo su $OE_USER -c "mkdir $OE_HOME/enterprise"
     sudo su $OE_USER -c "mkdir $OE_HOME/enterprise/addons"
 	
     echo -e "\n---- Adding Enterprise code under $OE_HOME/enterprise/addons ----"
@@ -124,6 +122,9 @@ if [ $IS_ENTERPRISE = "True" ]; then
     sudo apt-get install nodejs npm
     sudo npm install -g less
     sudo npm install -g less-plugin-clean-css
+
+    echo -e "\n--- Create symlink for node"
+    sudo ln -s /usr/bin/nodejs /usr/bin/node
 else 
     echo -e "\n---- Create custom module directory ----"
     sudo su $OE_USER -c "mkdir $OE_HOME/custom"


### PR DESCRIPTION
I think its nice to use newest Postgresql which is version 9.6 since it has parallel query ability. But since the binary is not available yet in Ubuntu repository (but it is official already in Postgresql repository), the repository to add is unique to each Ubuntu version. This PR only assume you are using Ubuntu 16.04.