### PR TITLE
Lower privilege for setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This script can be safely used in a multi-odoo code base server because the defa
 
 ##### 1. Download the script:
 ```
-sudo wget https://raw.githubusercontent.com/Yenthe666/InstallScript/11.0/odoo_install.sh
+wget https://raw.githubusercontent.com/Yenthe666/InstallScript/11.0/odoo_install.sh
 ```
 ##### 2. Modify the parameters as you wish.
 There are a few things you can configure, this is the most used list:<br/>
@@ -19,11 +19,7 @@ There are a few things you can configure, this is the most used list:<br/>
 ```IS_ENTERPRISE``` will install the Enterprise version on top of ```11.0``` if you set it to ```True```, set it to ```False``` if you want the community version of Odoo 11.<br/>
 ```OE_SUPERADMIN``` is the master password for this Odoo installation.<br/>
 
-#### 3. Make the script executable
+##### 3. Execute the script:
 ```
-sudo chmod +x odoo_install.sh
-```
-##### 4. Execute the script:
-```
-sudo ./odoo_install.sh
+sh ./odoo_install.sh
 ```


### PR DESCRIPTION
* `sudo` isn't need for `wget`
* `sh` prevents needing `chmod`
* `odoo_install.sh` asks for credentials naturally