### PR TITLE
[FIX] Use correct reference for wkhtmltopdf

### DIFF
--- a/odoo_install.sh
+++ b/odoo_install.sh
@@ -34,8 +34,8 @@ OE_CONFIG="${OE_USER}-server"
 ##
 ###  WKHTMLTOPDF download links
 ## === Ubuntu Trusty x64 & x32 === (for other distributions please replace these two links,
-## in order to have correct version of wkhtmltox installed, for a danger note refer to 
-## https://www.odoo.com/documentation/8.0/setup/install.html#deb ):
+## in order to have correct version of wkhtmltopdf installed, for a danger note refer to 
+## hhttps://github.com/odoo/odoo/wiki/Wkhtmltopdf ):
 WKHTMLTOX_X64=https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.trusty_amd64.deb
 WKHTMLTOX_X32=https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.trusty_i386.deb
 


### PR DESCRIPTION
Maybe we can fix this on each version till v10 or at least v11 (as 10.0 will be dropped soon)