### PR TITLE
The CSS Preprocessor used changed from less to Sass

### DIFF
--- a/odoo_install.sh
+++ b/odoo_install.sh
@@ -140,8 +140,6 @@ if [ $IS_ENTERPRISE = "True" ]; then
     echo -e "\n---- Added Enterprise code under $OE_HOME/enterprise/addons ----"
     echo -e "\n---- Installing Enterprise specific libraries ----"
     sudo -H pip3 install num2words ofxparse dbfread ebaysdk firebase_admin pyOpenSSL
-    sudo npm install -g less
-    sudo npm install -g less-plugin-clean-css
 fi
 
 echo -e "\n---- Create custom module directory ----"


### PR DESCRIPTION
Changed in Odoo 12
The CSS preprocessor used changed from less to Sass. This means that
less is no longer required to run Odoo. The Sass compiler does not
require additional installation steps, since it is made available by
libsass-python