### PR TITLE
[FIX] Complie issues related to Cython and Gevent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This script is based on the install script from André Schenkels (https://github
 but goes a bit further and has been improved. This script will also give you the ability to define an xmlrpc_port in the .conf file that is generated under /etc/
 This script can be safely used in a multi-odoo code base server because the default Odoo port is changed BEFORE the Odoo is started.
 
+This script was further iterated due to installation dependency issues. The original is from (https://github.com/Yenthe666/InstallScript). The issue stems from "Build to Wheel errors" that occurred during the package installation. Specifically ```gevent==21.8.0``` and ```greenlet==1.1.2``` (Discovered by /ryumada). This just makes it a bit easier for me to just chuck it in. 
+
 ## Installing Nginx
 If you set the parameter ```INSTALL_NGINX``` to ```True``` you should also configure workers. Without workers you will probably get connection loss issues. Look at [the deployment guide from Odoo](https://www.odoo.com/documentation/17.0/administration/install/deploy.html) on how to configure workers.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you set the parameter ```INSTALL_NGINX``` to ```True``` you should also confi
 
 ##### 1. Download the script:
 ```
-sudo wget https://raw.githubusercontent.com/Yenthe666/InstallScript/17.0/odoo_install.sh
+sudo wget https://raw.githubusercontent.com/DrunkOne/InstallScript/17.0/odoo_install.sh
 ```
 ##### 2. Modify the parameters as you wish.
 There are a few things you can configure, this is the most used list:<br/>

--- a/odoo_install.sh
+++ b/odoo_install.sh
@@ -101,7 +101,7 @@ sudo apt-get install python3 python3-pip
 sudo apt-get install git python3-cffi build-essential wget python3-dev python3-venv python3-wheel libxslt-dev libzip-dev libldap2-dev libsasl2-dev python3-setuptools node-less libpng-dev libjpeg-dev gdebi -y
 
 echo -e "\n---- Install python packages/requirements ----"
-sudo -H pip3 install -r https://github.com/odoo/odoo/raw/${OE_VERSION}/requirements.txt
+sudo -H pip3 install -r https://github.com/DrunkOne/odoo/raw/${OE_VERSION}/requirements.txt
 
 echo -e "\n---- Installing nodeJS NPM and rtlcss for LTR support ----"
 sudo apt-get install nodejs npm -y
@@ -148,7 +148,7 @@ sudo chown $OE_USER:$OE_USER /var/log/$OE_USER
 # Install ODOO
 #--------------------------------------------------
 echo -e "\n==== Installing ODOO Server ===="
-sudo git clone --depth 1 --branch $OE_VERSION https://www.github.com/DrunkOne/odoo $OE_HOME_EXT/
+sudo git clone --depth 1 --branch $OE_VERSION https://www.github.com/odoo/odoo $OE_HOME_EXT/
 
 if [ $IS_ENTERPRISE = "True" ]; then
     # Odoo Enterprise install!

--- a/odoo_install.sh
+++ b/odoo_install.sh
@@ -101,7 +101,7 @@ sudo apt-get install python3 python3-pip
 sudo apt-get install git python3-cffi build-essential wget python3-dev python3-venv python3-wheel libxslt-dev libzip-dev libldap2-dev libsasl2-dev python3-setuptools node-less libpng-dev libjpeg-dev gdebi -y
 
 echo -e "\n---- Install python packages/requirements ----"
-sudo -H pip3 install -r https://github.com/DrunkOne/odoo/raw/${OE_VERSION}/requirements.txt
+sudo -H pip3 install -r https://github.com/DrunkOne/odoo-dep-packages/raw/${OE_VERSION}/requirements.txt
 
 echo -e "\n---- Installing nodeJS NPM and rtlcss for LTR support ----"
 sudo apt-get install nodejs npm -y

--- a/odoo_install.sh
+++ b/odoo_install.sh
@@ -41,7 +41,7 @@ WEBSITE_NAME="_"
 # Set the default Odoo longpolling port (you still have to use -c /etc/odoo-server.conf for example to use this.)
 LONGPOLLING_PORT="8072"
 # Set to "True" to install certbot and have ssl enabled, "False" to use http
-ENABLE_SSL="True"
+ENABLE_SSL="False"
 # Provide Email to register ssl certificate
 ADMIN_EMAIL="odoo@example.com"
 ##
@@ -148,7 +148,7 @@ sudo chown $OE_USER:$OE_USER /var/log/$OE_USER
 # Install ODOO
 #--------------------------------------------------
 echo -e "\n==== Installing ODOO Server ===="
-sudo git clone --depth 1 --branch $OE_VERSION https://www.github.com/odoo/odoo $OE_HOME_EXT/
+sudo git clone --depth 1 --branch $OE_VERSION https://www.github.com/DrunkOne/odoo $OE_HOME_EXT/
 
 if [ $IS_ENTERPRISE = "True" ]; then
     # Odoo Enterprise install!


### PR DESCRIPTION
All it does is reroute the requirement.txt file to my repository, that `requirement.txt` is able to follow version `OE_VERSION`.

As this is a temp fix it hopes to improve the use installation experience until Odoo updates the repository themselves.

All my "requirement.txt" file does is comment out `#` the previous versions of `gevent==21.8.0` and `greenlet==1.1.2`

Appended the comparator from `>` to `>=` for the next iteration. 
