### PR TITLE
[FIX] Compile issues related to Cython and Gevent causing issues in dependency packages

### DIFF
--- a/odoo_install.sh
+++ b/odoo_install.sh
@@ -101,7 +101,7 @@ sudo apt-get install python3 python3-pip
 sudo apt-get install git python3-cffi build-essential wget python3-dev python3-venv python3-wheel libxslt-dev libzip-dev libldap2-dev libsasl2-dev python3-setuptools node-less libpng-dev libjpeg-dev gdebi -y
 
 echo -e "\n---- Install python packages/requirements ----"
-sudo -H pip3 install -r https://github.com/odoo/odoo/raw/${OE_VERSION}/requirements.txt
+sudo -H pip3 install -r https://github.com/DrunkOne/odoo-dep-packages/raw/${OE_VERSION}/requirements.txt
 
 echo -e "\n---- Installing nodeJS NPM and rtlcss for LTR support ----"
 sudo apt-get install nodejs npm -y


### PR DESCRIPTION
All it does is reroute the requirement.txt file to my repository, that requirement.txt is able to follow version OE_VERSION.

As this is a temp fix it hopes to improve the use installation experience until Odoo updates the repository themselves.

All my "requirement.txt" file does is comment out # the previous versions of gevent==21.8.0 and greenlet==1.1.2

Appended the comparator from > to >= for the next iteration.