### PR TITLE
[ADD] installscript: implement Python virtual environment for package…

### DIFF
--- a/odoo_install.sh
+++ b/odoo_install.sh
@@ -17,6 +17,7 @@
 OE_USER="odoo"
 OE_HOME="/$OE_USER"
 OE_HOME_EXT="/$OE_USER/${OE_USER}-server"
+OE_VENV="$OE_HOME/venv"
 # The default port where this Odoo instance will run under (provided you use the command -c in the terminal)
 # Set to true if you want to install it, false if you don't need it or have it already installed.
 INSTALL_WKHTMLTOPDF="True"
@@ -45,15 +46,6 @@ ENABLE_SSL="True"
 # Provide Email to register ssl certificate
 ADMIN_EMAIL="odoo@example.com"
 
-# Helper: pip install with optional --break-system-packages (Ubuntu 24.04 / PEP 668)
-pip_install() {
-  if pip3 help install 2>/dev/null | grep -q -- '--break-system-packages'; then
-    sudo -H pip3 install --break-system-packages "$@"
-  else
-    sudo -H pip3 install "$@"
-  fi
-}
-##
 
 ## ### WKHTMLTOPDF download & arch detection (x86/x86_64/ARM) ##
 # Installed from the Ubuntu 24.04 repositories
@@ -144,12 +136,6 @@ echo -e "\n--- Installing Python 3 + pip3 --"
 sudo apt-get install -y python3 python3-pip
 sudo apt-get install git python3-cffi build-essential wget python3-dev python3-venv python3-wheel libxslt-dev libzip-dev libldap2-dev libsasl2-dev python3-setuptools node-less libpng-dev libjpeg-dev gdebi -y
 
-echo -e "\n---- Install python packages/requirements ----"
-pip_install -r https://github.com/odoo/odoo/raw/${OE_VERSION}/requirements.txt
-
-# Extra: ensure phonenumbers is installed
-pip_install phonenumbers
-
 echo -e "\n---- Installing nodeJS NPM and rtlcss for LTR support ----"
 sudo apt-get install nodejs npm -y
 sudo npm install -g rtlcss
@@ -193,9 +179,19 @@ sudo chown $OE_USER:$OE_USER /var/log/$OE_USER
 echo -e "\n==== Installing ODOO Server ===="
 sudo git clone --depth 1 --branch $OE_VERSION https://www.github.com/odoo/odoo $OE_HOME_EXT/
 
+echo -e "\n---- Create Python virtual environment ----"
+sudo -u $OE_USER python3 -m venv $OE_VENV
+sudo -u $OE_USER $OE_VENV/bin/pip3 install --upgrade pip
+
+echo -e "\n---- Install python packages/requirements in virtual environment ----"
+sudo -u $OE_USER $OE_VENV/bin/pip3 install -r https://github.com/odoo/odoo/raw/${OE_VERSION}/requirements.txt
+
+# Extra: ensure phonenumbers is installed
+sudo -u $OE_USER $OE_VENV/bin/pip3 install phonenumbers
+
 if [ $IS_ENTERPRISE = "True" ]; then
     # Odoo Enterprise install!
-    pip_install psycopg2-binary pdfminer.six
+    sudo -u $OE_USER $OE_VENV/bin/pip3 install psycopg2-binary pdfminer.six
     sudo su $OE_USER -c "mkdir $OE_HOME/enterprise"
     sudo su $OE_USER -c "mkdir $OE_HOME/enterprise/addons"
 
@@ -212,7 +208,7 @@ if [ $IS_ENTERPRISE = "True" ]; then
 
     echo -e "\n---- Added Enterprise code under $OE_HOME/enterprise/addons ----"
     echo -e "\n---- Installing Enterprise specific libraries ----"
-    pip_install num2words ofxparse dbfread ebaysdk firebase_admin pyOpenSSL
+    sudo -u $OE_USER $OE_VENV/bin/pip3 install num2words ofxparse dbfread ebaysdk firebase_admin pyOpenSSL
     sudo npm install -g less
     sudo npm install -g less-plugin-clean-css
 fi
@@ -252,7 +248,7 @@ sudo chmod 640 /etc/${OE_CONFIG}.conf
 
 echo -e "* Create startup file"
 sudo su root -c "echo '#!/bin/sh' >> $OE_HOME_EXT/start.sh"
-sudo su root -c "echo 'sudo -u $OE_USER $OE_HOME_EXT/odoo-bin --config=/etc/${OE_CONFIG}.conf' >> $OE_HOME_EXT/start.sh"
+sudo su root -c "echo 'sudo -u $OE_USER $OE_VENV/bin/python3 $OE_HOME_EXT/odoo-bin --config=/etc/${OE_CONFIG}.conf' >> $OE_HOME_EXT/start.sh"
 sudo chmod 755 $OE_HOME_EXT/start.sh
 
 #--------------------------------------------------
@@ -274,7 +270,7 @@ cat <<EOF > ~/$OE_CONFIG
 # Description: ODOO Business Applications
 ### END INIT INFO
 PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
-DAEMON=$OE_HOME_EXT/odoo-bin
+DAEMON=$OE_VENV/bin/python3
 NAME=$OE_CONFIG
 DESC=$OE_CONFIG
 # Specify the user name (Default: odoo).
@@ -284,7 +280,7 @@ CONFIGFILE="/etc/${OE_CONFIG}.conf"
 # pidfile
 PIDFILE=/var/run/\${NAME}.pid
 # Additional options that are passed to the Daemon.
-DAEMON_OPTS="-c \$CONFIGFILE"
+DAEMON_OPTS="$OE_HOME_EXT/odoo-bin -c \$CONFIGFILE"
 [ -x \$DAEMON ] || exit 0
 [ -f \$CONFIGFILE ] || exit 0
 checkpid() {


### PR DESCRIPTION

This pull request refactors the Odoo installation script to use a Python virtual environment for all Python package installations, improving isolation and compatibility, especially for Ubuntu 24.04 and later. It removes the custom `pip_install` helper and updates startup and service scripts to launch Odoo using the virtual environment's Python interpreter.

Python environment and package management:

* Introduced a dedicated Python virtual environment at `OE_VENV` and updated all Python package installations to use this environment, replacing direct system-wide installations. [[1]](diffhunk://#diff-c9304201323b64b0c5aae107cf197bcf68b0559467ef2a48ab9afbfe17f8ab3bR20) [[2]](diffhunk://#diff-c9304201323b64b0c5aae107cf197bcf68b0559467ef2a48ab9afbfe17f8ab3bR182-R194) [[3]](diffhunk://#diff-c9304201323b64b0c5aae107cf197bcf68b0559467ef2a48ab9afbfe17f8ab3bL215-R211)
* Removed the custom `pip_install` helper function, simplifying package installation logic and avoiding potential issues with system package conflicts. [[1]](diffhunk://#diff-c9304201323b64b0c5aae107cf197bcf68b0559467ef2a48ab9afbfe17f8ab3bL48-L56) [[2]](diffhunk://#diff-c9304201323b64b0c5aae107cf197bcf68b0559467ef2a48ab9afbfe17f8ab3bL147-L152)

Startup and service script updates:

* Modified the `start.sh` script to launch Odoo using the virtual environment's Python interpreter instead of the system Python.
* Updated the service definition to set `DAEMON` to the virtual environment's Python and adjusted `DAEMON_OPTS` to include the Odoo binary and config file. [[1]](diffhunk://#diff-c9304201323b64b0c5aae107cf197bcf68b0559467ef2a48ab9afbfe17f8ab3bL277-R273) [[2]](diffhunk://#diff-c9304201323b64b0c5aae107cf197bcf68b0559467ef2a48ab9afbfe17f8ab3bL287-R283)