### PR TITLE
Create Odoo PostgreSQL role without SUPERUSER (prevents COPY FROM PROGRAM RCE)

### DIFF
--- a/odoo_install.sh
+++ b/odoo_install.sh
@@ -135,7 +135,13 @@ else
 fi
 
 echo -e "\n---- Creating the ODOO PostgreSQL User  ----"
-sudo su - postgres -c "createuser -s $OE_USER" 2> /dev/null || true
+# Create the role with CREATEDB (Odoo needs it to create/drop databases) but WITHOUT
+# SUPERUSER. A superuser role can run 'COPY ... FROM PROGRAM', which lets anyone who
+# reaches an Odoo admin turn SQL access into shell command execution as the postgres
+# OS user. Keeping the role non-superuser closes that privilege-escalation path and
+# matches Odoo's deployment guidance. See:
+# https://www.odoo.com/documentation/19.0/administration/on_premise/deploy.html
+sudo su - postgres -c "createuser -d -R -S $OE_USER" 2> /dev/null || true
 
 #--------------------------------------------------
 # Install Dependencies
@@ -235,6 +241,11 @@ if [ $GENERATE_RANDOM_PASSWORD = "True" ]; then
     OE_SUPERADMIN=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
 fi
 sudo su root -c "printf 'admin_passwd = ${OE_SUPERADMIN}\n' >> /etc/${OE_CONFIG}.conf"
+# Security: once your database(s) exist, set list_db = False to disable the
+# unauthenticated database selector/manager (/web/database/*), which otherwise
+# lets anyone enumerate database names. Left commented so the web database
+# manager still works for creating the first database right after install.
+sudo su root -c "printf '; list_db = False\n' >> /etc/${OE_CONFIG}.conf"
 if [ $OE_VERSION > "11.0" ];then
     sudo su root -c "printf 'http_port = ${OE_PORT}\n' >> /etc/${OE_CONFIG}.conf"
 else


### PR DESCRIPTION
### What
Change the PostgreSQL role creation from `createuser -s` (SUPERUSER) to `createuser -d -R -S` (CREATEDB, no SUPERUSER, no CREATEROLE), and add a commented `list_db = False` hint to the generated config.

### Why
A PostgreSQL **superuser** role can run `COPY ... FROM PROGRAM '<cmd>'`. Because Odoo connects to the database with this role, anyone who reaches an Odoo administrator — for example through an exposed database manager (`list_db = True`) or a weak admin password — can create a server action that issues `COPY ... FROM PROGRAM` and execute arbitrary shell commands as the `postgres` OS user. This is a well-documented cryptojacking vector against internet-facing Odoo deployments.

Odoo only needs **CREATEDB** to create and drop databases; it does not need SUPERUSER. Dropping superuser closes the privilege-escalation path with no impact on normal operation, and aligns with Odoo's own deployment guidance:
https://www.odoo.com/documentation/19.0/administration/on_premise/deploy.html

### Changes
- `createuser -s $OE_USER` → `createuser -d -R -S $OE_USER` (with an explanatory comment).
- Add a commented `; list_db = False` line to the generated config, with a note to enable it once databases exist. It is left commented so first-run database creation via the web manager still works.

### Compatibility / impact
- The role keeps `CREATEDB`, so creating/dropping databases, running tests, and the database manager all continue to work.
- No behavioural change to ports, addons paths, or the nginx/proxy_mode logic.
- `bash -n odoo_install.sh` passes.

### Notes for existing installs
Operators who already installed with a superuser role can remediate without reinstalling:
```
sudo -u postgres psql -c "ALTER ROLE odoo NOSUPERUSER;"
sudo -u postgres psql -c "REVOKE pg_execute_server_program, pg_read_server_files, pg_write_server_files FROM odoo;"
```